### PR TITLE
Export BGP internals to make BGP package usable from outside modules

### DIFF
--- a/patches/0011-speaker-Export-session-interface.patch
+++ b/patches/0011-speaker-Export-session-interface.patch
@@ -1,0 +1,60 @@
+From 4085820736c629bee184fa128f8e2af9be77b6b2 Mon Sep 17 00:00:00 2001
+From: Chris Tarazi <chris@isovalent.com>
+Date: Fri, 9 Apr 2021 13:45:42 -0700
+Subject: [PATCH 1/2] speaker: Export session interface
+
+In the next commit, this interface will be used by outside modules.
+
+Signed-off-by: Chris Tarazi <chris@isovalent.com>
+---
+ pkg/speaker/bgp_controller.go      | 7 ++++---
+ pkg/speaker/bgp_controller_test.go | 2 +-
+ 2 files changed, 5 insertions(+), 4 deletions(-)
+
+diff --git a/pkg/speaker/bgp_controller.go b/pkg/speaker/bgp_controller.go
+index d369c6cb..e075381d 100644
+--- a/pkg/speaker/bgp_controller.go
++++ b/pkg/speaker/bgp_controller.go
+@@ -34,7 +34,7 @@ import (
+ 
+ type peer struct {
+ 	cfg *config.Peer
+-	bgp session
++	bgp Session
+ }
+ 
+ type BGPController struct {
+@@ -246,7 +246,8 @@ func (c *BGPController) DeleteBalancer(l log.Logger, name, reason string) error
+ 	return c.updateAds()
+ }
+ 
+-type session interface {
++// Session gives access to the BGP session.
++type Session interface {
+ 	io.Closer
+ 	Set(advs ...*bgp.Advertisement) error
+ }
+@@ -265,6 +266,6 @@ func (c *BGPController) SetNodeLabels(l log.Logger, lbls map[string]string) erro
+ 	return c.syncPeers(l)
+ }
+ 
+-var newBGP = func(logger log.Logger, addr string, myASN uint32, routerID net.IP, asn uint32, hold time.Duration, password string, myNode string) (session, error) {
++var newBGP = func(logger log.Logger, addr string, myASN uint32, routerID net.IP, asn uint32, hold time.Duration, password string, myNode string) (Session, error) {
+ 	return bgp.New(logger, addr, myASN, routerID, asn, hold, password, myNode)
+ }
+diff --git a/pkg/speaker/bgp_controller_test.go b/pkg/speaker/bgp_controller_test.go
+index 587f059e..f89d1b84 100644
+--- a/pkg/speaker/bgp_controller_test.go
++++ b/pkg/speaker/bgp_controller_test.go
+@@ -92,7 +92,7 @@ type fakeBGP struct {
+ 	gotAds map[string][]*bgp.Advertisement
+ }
+ 
+-func (f *fakeBGP) New(_ log.Logger, addr string, _ uint32, _ net.IP, _ uint32, _ time.Duration, _, _ string) (session, error) {
++func (f *fakeBGP) New(_ log.Logger, addr string, _ uint32, _ net.IP, _ uint32, _ time.Duration, _, _ string) (Session, error) {
+ 	f.Lock()
+ 	defer f.Unlock()
+ 
+-- 
+2.31.1
+

--- a/patches/0012-speaker-Expose-BGP-peer-sessions.patch
+++ b/patches/0012-speaker-Expose-BGP-peer-sessions.patch
@@ -1,0 +1,72 @@
+From 4db306a8dd836b7d9f0f5a1d052ae0c426275017 Mon Sep 17 00:00:00 2001
+From: Chris Tarazi <chris@isovalent.com>
+Date: Wed, 7 Apr 2021 17:11:19 -0700
+Subject: [PATCH 2/2] speaker: Expose BGP peer sessions
+
+This allows consumers direct access to the BGP peering sessions. This is
+useful to reusing the sessions to advertise arbitrary IPs / CIDRs.
+
+Signed-off-by: Chris Tarazi <chris@isovalent.com>
+---
+ pkg/speaker/bgp_controller.go | 15 ++++++++++++---
+ pkg/speaker/speaker.go        |  9 +++++++++
+ 2 files changed, 21 insertions(+), 3 deletions(-)
+
+diff --git a/pkg/speaker/bgp_controller.go b/pkg/speaker/bgp_controller.go
+index e075381d..c4601a5f 100644
+--- a/pkg/speaker/bgp_controller.go
++++ b/pkg/speaker/bgp_controller.go
+@@ -227,11 +227,11 @@ func (c *BGPController) updateAds() error {
+ 		// and detecting conflicting advertisements.
+ 		allAds = append(allAds, ads...)
+ 	}
+-	for _, peer := range c.peers {
+-		if peer.bgp == nil {
++	for _, session := range c.PeerSessions() {
++		if session == nil {
+ 			continue
+ 		}
+-		if err := peer.bgp.Set(allAds...); err != nil {
++		if err := session.Set(allAds...); err != nil {
+ 			return err
+ 		}
+ 	}
+@@ -266,6 +266,15 @@ func (c *BGPController) SetNodeLabels(l log.Logger, lbls map[string]string) erro
+ 	return c.syncPeers(l)
+ }
+ 
++// PeerSessions returns the underlying BGP sessions for direct use.
++func (c *BGPController) PeerSessions() []Session {
++	s := make([]Session, len(c.peers))
++	for i, peer := range c.peers {
++		s[i] = peer.bgp
++	}
++	return s
++}
++
+ var newBGP = func(logger log.Logger, addr string, myASN uint32, routerID net.IP, asn uint32, hold time.Duration, password string, myNode string) (Session, error) {
+ 	return bgp.New(logger, addr, myASN, routerID, asn, hold, password, myNode)
+ }
+diff --git a/pkg/speaker/speaker.go b/pkg/speaker/speaker.go
+index 55190b6d..5d384dfb 100644
+--- a/pkg/speaker/speaker.go
++++ b/pkg/speaker/speaker.go
+@@ -251,6 +251,15 @@ func (c *Controller) SetNodeLabels(l gokitlog.Logger, labels map[string]string)
+ 	return types.SyncStateSuccess
+ }
+ 
++// PeerSessions returns the underlying BGP sessions from the BGP controller. In
++// Layer2 mode only, this returns nil.
++func (c *Controller) PeerSessions() []Session {
++	if handler, ok := c.protocols[config.BGP]; ok {
++		return handler.(*BGPController).PeerSessions()
++	}
++	return nil
++}
++
+ // Endpoints represents an object containing the minimal representation of a
+ // v1.Endpoints similar to Service.
+ type Endpoints struct {
+-- 
+2.31.1
+

--- a/pkg/speaker/bgp_controller.go
+++ b/pkg/speaker/bgp_controller.go
@@ -34,7 +34,7 @@ import (
 
 type peer struct {
 	cfg *config.Peer
-	bgp session
+	bgp Session
 }
 
 type BGPController struct {
@@ -246,7 +246,8 @@ func (c *BGPController) DeleteBalancer(l log.Logger, name, reason string) error 
 	return c.updateAds()
 }
 
-type session interface {
+// Session gives access to the BGP session.
+type Session interface {
 	io.Closer
 	Set(advs ...*bgp.Advertisement) error
 }
@@ -265,6 +266,6 @@ func (c *BGPController) SetNodeLabels(l log.Logger, lbls map[string]string) erro
 	return c.syncPeers(l)
 }
 
-var newBGP = func(logger log.Logger, addr string, myASN uint32, routerID net.IP, asn uint32, hold time.Duration, password string, myNode string) (session, error) {
+var newBGP = func(logger log.Logger, addr string, myASN uint32, routerID net.IP, asn uint32, hold time.Duration, password string, myNode string) (Session, error) {
 	return bgp.New(logger, addr, myASN, routerID, asn, hold, password, myNode)
 }

--- a/pkg/speaker/bgp_controller.go
+++ b/pkg/speaker/bgp_controller.go
@@ -227,11 +227,11 @@ func (c *BGPController) updateAds() error {
 		// and detecting conflicting advertisements.
 		allAds = append(allAds, ads...)
 	}
-	for _, peer := range c.peers {
-		if peer.bgp == nil {
+	for _, session := range c.PeerSessions() {
+		if session == nil {
 			continue
 		}
-		if err := peer.bgp.Set(allAds...); err != nil {
+		if err := session.Set(allAds...); err != nil {
 			return err
 		}
 	}
@@ -264,6 +264,15 @@ func (c *BGPController) SetNodeLabels(l log.Logger, lbls map[string]string) erro
 	c.nodeLabels = ns
 	l.Log("event", "nodeLabelsChanged", "msg", "Node labels changed, resyncing BGP peers")
 	return c.syncPeers(l)
+}
+
+// PeerSessions returns the underlying BGP sessions for direct use.
+func (c *BGPController) PeerSessions() []Session {
+	s := make([]Session, len(c.peers))
+	for i, peer := range c.peers {
+		s[i] = peer.bgp
+	}
+	return s
 }
 
 var newBGP = func(logger log.Logger, addr string, myASN uint32, routerID net.IP, asn uint32, hold time.Duration, password string, myNode string) (Session, error) {

--- a/pkg/speaker/bgp_controller_test.go
+++ b/pkg/speaker/bgp_controller_test.go
@@ -92,7 +92,7 @@ type fakeBGP struct {
 	gotAds map[string][]*bgp.Advertisement
 }
 
-func (f *fakeBGP) New(_ log.Logger, addr string, _ uint32, _ net.IP, _ uint32, _ time.Duration, _, _ string) (session, error) {
+func (f *fakeBGP) New(_ log.Logger, addr string, _ uint32, _ net.IP, _ uint32, _ time.Duration, _, _ string) (Session, error) {
 	f.Lock()
 	defer f.Unlock()
 

--- a/pkg/speaker/speaker.go
+++ b/pkg/speaker/speaker.go
@@ -251,6 +251,15 @@ func (c *Controller) SetNodeLabels(l gokitlog.Logger, labels map[string]string) 
 	return types.SyncStateSuccess
 }
 
+// PeerSessions returns the underlying BGP sessions from the BGP controller. In
+// Layer2 mode only, this returns nil.
+func (c *Controller) PeerSessions() []Session {
+	if handler, ok := c.protocols[config.BGP]; ok {
+		return handler.(*BGPController).PeerSessions()
+	}
+	return nil
+}
+
 // Endpoints represents an object containing the minimal representation of a
 // v1.Endpoints similar to Service.
 type Endpoints struct {


### PR DESCRIPTION
- speaker: Export session interface
- speaker: Expose BGP peer sessions
- patches: add patches for exporting bgp internals 