### PR TITLE
speaker: Expose bgp_controller peers

### DIFF
--- a/patches/0015-speaker-exposed-bgpcontroller-peers.patch
+++ b/patches/0015-speaker-exposed-bgpcontroller-peers.patch
@@ -1,0 +1,131 @@
+From 2d6c05b843478251eae14c9d4393405a774e38a1 Mon Sep 17 00:00:00 2001
+From: Dylan Reimerink <dylan.reimerink@isovalent.com>
+Date: Wed, 13 Jul 2022 15:42:51 +0200
+Subject: [PATCH] speaker: Expose bgp_controller peers
+
+Now that we interact with the BGP controller directly, we also need
+access to its peers so we can set them during mocking/unit testing.
+
+Signed-off-by: Dylan Reimerink <dylan.reimerink@isovalent.com>
+---
+ pkg/speaker/bgp_controller.go | 40 +++++++++++++++++------------------
+ 1 file changed, 20 insertions(+), 20 deletions(-)
+
+diff --git a/pkg/speaker/bgp_controller.go b/pkg/speaker/bgp_controller.go
+index 16c6411e..c257ab17 100644
+--- a/pkg/speaker/bgp_controller.go
++++ b/pkg/speaker/bgp_controller.go
+@@ -32,49 +32,49 @@ import (
+ 	"github.com/go-kit/kit/log"
+ )
+ 
+-type peer struct {
++type Peer struct {
+ 	cfg *config.Peer
+-	bgp Session
++	BGP Session
+ }
+ 
+ type BGPController struct {
+ 	Logger     log.Logger
+ 	MyNode     string
+ 	nodeLabels labels.Set
+-	peers      []*peer
++	Peers      []*Peer
+ 	SvcAds     map[string][]*bgp.Advertisement
+ }
+ 
+ func (c *BGPController) SetConfig(l log.Logger, cfg *config.Config) error {
+-	newPeers := make([]*peer, 0, len(cfg.Peers))
++	newPeers := make([]*Peer, 0, len(cfg.Peers))
+ newPeers:
+ 	for _, p := range cfg.Peers {
+-		for i, ep := range c.peers {
++		for i, ep := range c.Peers {
+ 			if ep == nil {
+ 				continue
+ 			}
+ 			if reflect.DeepEqual(p, ep.cfg) {
+ 				newPeers = append(newPeers, ep)
+-				c.peers[i] = nil
++				c.Peers[i] = nil
+ 				continue newPeers
+ 			}
+ 		}
+ 		// No existing peers match, create a new one.
+-		newPeers = append(newPeers, &peer{
++		newPeers = append(newPeers, &Peer{
+ 			cfg: p,
+ 		})
+ 	}
+ 
+-	oldPeers := c.peers
+-	c.peers = newPeers
++	oldPeers := c.Peers
++	c.Peers = newPeers
+ 
+ 	for _, p := range oldPeers {
+ 		if p == nil {
+ 			continue
+ 		}
+ 		l.Log("event", "peerRemoved", "peer", p.cfg.Addr, "reason", "removedFromConfig", "msg", "peer deconfigured, closing BGP session")
+-		if p.bgp != nil {
+-			if err := p.bgp.Close(); err != nil {
++		if p.BGP != nil {
++			if err := p.BGP.Close(); err != nil {
+ 				l.Log("op", "setConfig", "error", err, "peer", p.cfg.Addr, "msg", "failed to shut down BGP session")
+ 			}
+ 		}
+@@ -139,7 +139,7 @@ func (c *BGPController) syncPeers(l log.Logger) error {
+ 		errs          int
+ 		needUpdateAds bool
+ 	)
+-	for _, p := range c.peers {
++	for _, p := range c.Peers {
+ 		// First, determine if the peering should be active for this
+ 		// node.
+ 		shouldRun := false
+@@ -151,14 +151,14 @@ func (c *BGPController) syncPeers(l log.Logger) error {
+ 		}
+ 
+ 		// Now, compare current state to intended state, and correct.
+-		if p.bgp != nil && !shouldRun {
++		if p.BGP != nil && !shouldRun {
+ 			// Oops, session is running but shouldn't be. Shut it down.
+ 			l.Log("event", "peerRemoved", "peer", p.cfg.Addr, "reason", "filteredByNodeSelector", "msg", "peer deconfigured, closing BGP session")
+-			if err := p.bgp.Close(); err != nil {
++			if err := p.BGP.Close(); err != nil {
+ 				l.Log("op", "syncPeers", "error", err, "peer", p.cfg.Addr, "msg", "failed to shut down BGP session")
+ 			}
+-			p.bgp = nil
+-		} else if p.bgp == nil && shouldRun {
++			p.BGP = nil
++		} else if p.BGP == nil && shouldRun {
+ 			// Session doesn't exist, but should be running. Create
+ 			// it.
+ 			l.Log("event", "peerAdded", "peer", p.cfg.Addr, "msg", "peer configured, starting BGP session")
+@@ -171,7 +171,7 @@ func (c *BGPController) syncPeers(l log.Logger) error {
+ 				l.Log("op", "syncPeers", "error", err, "peer", p.cfg.Addr, "msg", "failed to create BGP session")
+ 				errs++
+ 			} else {
+-				p.bgp = s
++				p.BGP = s
+ 				needUpdateAds = true
+ 			}
+ 		}
+@@ -268,9 +268,9 @@ func (c *BGPController) SetNodeLabels(l log.Logger, lbls map[string]string) erro
+ 
+ // PeerSessions returns the underlying BGP sessions for direct use.
+ func (c *BGPController) PeerSessions() []Session {
+-	s := make([]Session, len(c.peers))
+-	for i, peer := range c.peers {
+-		s[i] = peer.bgp
++	s := make([]Session, len(c.Peers))
++	for i, peer := range c.Peers {
++		s[i] = peer.BGP
+ 	}
+ 	return s
+ }
+-- 
+2.35.1
+

--- a/pkg/speaker/bgp_controller.go
+++ b/pkg/speaker/bgp_controller.go
@@ -32,49 +32,49 @@ import (
 	"github.com/go-kit/kit/log"
 )
 
-type peer struct {
+type Peer struct {
 	cfg *config.Peer
-	bgp Session
+	BGP Session
 }
 
 type BGPController struct {
 	Logger     log.Logger
 	MyNode     string
 	nodeLabels labels.Set
-	peers      []*peer
+	Peers      []*Peer
 	SvcAds     map[string][]*bgp.Advertisement
 }
 
 func (c *BGPController) SetConfig(l log.Logger, cfg *config.Config) error {
-	newPeers := make([]*peer, 0, len(cfg.Peers))
+	newPeers := make([]*Peer, 0, len(cfg.Peers))
 newPeers:
 	for _, p := range cfg.Peers {
-		for i, ep := range c.peers {
+		for i, ep := range c.Peers {
 			if ep == nil {
 				continue
 			}
 			if reflect.DeepEqual(p, ep.cfg) {
 				newPeers = append(newPeers, ep)
-				c.peers[i] = nil
+				c.Peers[i] = nil
 				continue newPeers
 			}
 		}
 		// No existing peers match, create a new one.
-		newPeers = append(newPeers, &peer{
+		newPeers = append(newPeers, &Peer{
 			cfg: p,
 		})
 	}
 
-	oldPeers := c.peers
-	c.peers = newPeers
+	oldPeers := c.Peers
+	c.Peers = newPeers
 
 	for _, p := range oldPeers {
 		if p == nil {
 			continue
 		}
 		l.Log("event", "peerRemoved", "peer", p.cfg.Addr, "reason", "removedFromConfig", "msg", "peer deconfigured, closing BGP session")
-		if p.bgp != nil {
-			if err := p.bgp.Close(); err != nil {
+		if p.BGP != nil {
+			if err := p.BGP.Close(); err != nil {
 				l.Log("op", "setConfig", "error", err, "peer", p.cfg.Addr, "msg", "failed to shut down BGP session")
 			}
 		}
@@ -139,7 +139,7 @@ func (c *BGPController) syncPeers(l log.Logger) error {
 		errs          int
 		needUpdateAds bool
 	)
-	for _, p := range c.peers {
+	for _, p := range c.Peers {
 		// First, determine if the peering should be active for this
 		// node.
 		shouldRun := false
@@ -151,14 +151,14 @@ func (c *BGPController) syncPeers(l log.Logger) error {
 		}
 
 		// Now, compare current state to intended state, and correct.
-		if p.bgp != nil && !shouldRun {
+		if p.BGP != nil && !shouldRun {
 			// Oops, session is running but shouldn't be. Shut it down.
 			l.Log("event", "peerRemoved", "peer", p.cfg.Addr, "reason", "filteredByNodeSelector", "msg", "peer deconfigured, closing BGP session")
-			if err := p.bgp.Close(); err != nil {
+			if err := p.BGP.Close(); err != nil {
 				l.Log("op", "syncPeers", "error", err, "peer", p.cfg.Addr, "msg", "failed to shut down BGP session")
 			}
-			p.bgp = nil
-		} else if p.bgp == nil && shouldRun {
+			p.BGP = nil
+		} else if p.BGP == nil && shouldRun {
 			// Session doesn't exist, but should be running. Create
 			// it.
 			l.Log("event", "peerAdded", "peer", p.cfg.Addr, "msg", "peer configured, starting BGP session")
@@ -171,7 +171,7 @@ func (c *BGPController) syncPeers(l log.Logger) error {
 				l.Log("op", "syncPeers", "error", err, "peer", p.cfg.Addr, "msg", "failed to create BGP session")
 				errs++
 			} else {
-				p.bgp = s
+				p.BGP = s
 				needUpdateAds = true
 			}
 		}
@@ -268,9 +268,9 @@ func (c *BGPController) SetNodeLabels(l log.Logger, lbls map[string]string) erro
 
 // PeerSessions returns the underlying BGP sessions for direct use.
 func (c *BGPController) PeerSessions() []Session {
-	s := make([]Session, len(c.peers))
-	for i, peer := range c.peers {
-		s[i] = peer.bgp
+	s := make([]Session, len(c.Peers))
+	for i, peer := range c.Peers {
+		s[i] = peer.BGP
 	}
 	return s
 }


### PR DESCRIPTION
Now that we interact with the BGP controller directly, we also need
access to its peers so we can set them during mocking/unit testing.